### PR TITLE
Properly declare the member functions

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -31,11 +31,11 @@ export default {
     }
   },
 
-  activate: () => {
+  activate() {
     require("atom-package-deps").install();
   },
 
-  provideLinter: () => {
+  provideLinter() {
     return {
       name: "ruby-lint",
       grammarScopes: ["source.ruby", "source.ruby.rails", "source.ruby.rspec"],


### PR DESCRIPTION
Function declaration using an arrow function in the global scope is invalid, and the cleaner transpilation in Atom v1.16.0 breaks on this method.

See https://github.com/atom/atom/pull/13823#issuecomment-286985411 for details.